### PR TITLE
Feat/18 order 생성 기능 추가

### DIFF
--- a/module-api/src/main/java/com/example/api/config/JwtFilter.java
+++ b/module-api/src/main/java/com/example/api/config/JwtFilter.java
@@ -1,0 +1,51 @@
+package com.example.api.config;
+
+import com.example.api.facade.user.UserFacade;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+	private final JwtUtil jwtUtil;
+	private final UserFacade userFacade;
+
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+		final String auth = request.getHeader("Authorization");
+
+		if (auth == null || !auth.regionMatches(true, 0, "Bearer ", 0, 7)) {
+			filterChain.doFilter(request, response);
+			return;
+		}
+
+		String token = auth.substring(7);
+		if (token.isEmpty()) {
+			filterChain.doFilter(request, response);
+			return;
+		}
+
+		try {
+			Authentication authentication = jwtUtil.getAuthentication(token);
+
+			SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		} catch (Exception e) {
+			// 인증 실패는 401로 내려가게 하고 로그만 남김
+			// 필요 시 response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+			// return;  // 보통은 ExceptionTranslationFilter가 처리하게 흘려보냅니다.
+		}
+
+		filterChain.doFilter(request, response);
+	}
+
+}

--- a/module-api/src/main/java/com/example/api/config/JwtUtil.java
+++ b/module-api/src/main/java/com/example/api/config/JwtUtil.java
@@ -41,7 +41,7 @@ public class JwtUtil {
 	public String generateToken(String userId) {
 		return Jwts.builder()
 			.subject(userId)
-			.claim("role", "USER")
+			.claim("roles", "ROLE_USER")
 			.issuedAt(new Date())
 			.expiration(new Date(System.currentTimeMillis() + exp))
 			.signWith(key)
@@ -56,7 +56,7 @@ public class JwtUtil {
 			.build()
 			.parseSignedClaims(token).getPayload();
 
-		String roles = claims.get("role", String.class);
+		String roles = claims.get("roles", String.class);
 
 		if (roles == null) {
 			throw new ApiException("권한 정보가 없는 토큰입니다.", ErrorType.INVALID_TOKEN,
@@ -74,7 +74,8 @@ public class JwtUtil {
 
 	public boolean validateToken(String token) {
 		try {
-			Jwts.parser().setSigningKey(key).build().parseClaimsJws(token);
+			Jwts.parser().verifyWith(key).build().parseClaimsJws(token);
+
 			return true;
 		} catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
 			throw new ApiException("토큰이 잘못되었습니다.", ErrorType.INVALID_TOKEN,

--- a/module-api/src/main/java/com/example/api/config/JwtUtil.java
+++ b/module-api/src/main/java/com/example/api/config/JwtUtil.java
@@ -1,6 +1,5 @@
 package com.example.api.config;
 
-import com.example.api.facade.user.UserFacade;
 import com.example.api.infra.auth.CustomUserDetails;
 import com.example.common.exception.ApiException;
 import com.example.common.exception.ErrorType;
@@ -28,8 +27,7 @@ public class JwtUtil {
 	private final long exp;
 	private final SecretKey key;
 
-	public JwtUtil(@Value("${jwt.secret}") String secret, @Value("${jwt.expired}") long expired,
-		UserFacade userFacade) {
+	public JwtUtil(@Value("${jwt.secret}") String secret, @Value("${jwt.expired}") long expired) {
 		byte[] keyBytes = Decoders.BASE64.decode(secret);
 		this.key = Keys.hmacShaKeyFor(keyBytes);
 		this.exp = expired;

--- a/module-api/src/main/java/com/example/api/config/SecurityConfig.java
+++ b/module-api/src/main/java/com/example/api/config/SecurityConfig.java
@@ -1,17 +1,23 @@
 package com.example.api.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+	private final JwtFilter jwtFilter;
 
 	@Bean
 	public PasswordEncoder passwordEncoder() {
@@ -19,7 +25,7 @@ public class SecurityConfig {
 	}
 
 	@Bean
-	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+	public SecurityFilterChain filterChain(HttpSecurity http, JwtUtil jwtUtil) throws Exception {
 		return http
 			.httpBasic(AbstractHttpConfigurer::disable)
 			.csrf(AbstractHttpConfigurer::disable)
@@ -27,7 +33,7 @@ public class SecurityConfig {
 			.sessionManagement(httpSecuritySessionManagementConfigurer ->
 				httpSecuritySessionManagementConfigurer
 					.sessionCreationPolicy(
-						org.springframework.security.config.http.SessionCreationPolicy.STATELESS))
+						SessionCreationPolicy.STATELESS))
 			.authorizeHttpRequests(authorize -> authorize
 				.requestMatchers(
 					"/css/**",
@@ -45,6 +51,7 @@ public class SecurityConfig {
 				).permitAll()
 				.anyRequest().authenticated()
 			)
+			.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
 			.build();
 	}
 }

--- a/module-api/src/main/java/com/example/api/config/SecurityConfig.java
+++ b/module-api/src/main/java/com/example/api/config/SecurityConfig.java
@@ -25,7 +25,7 @@ public class SecurityConfig {
 	}
 
 	@Bean
-	public SecurityFilterChain filterChain(HttpSecurity http, JwtUtil jwtUtil) throws Exception {
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 		return http
 			.httpBasic(AbstractHttpConfigurer::disable)
 			.csrf(AbstractHttpConfigurer::disable)

--- a/module-api/src/main/java/com/example/api/controller/order/OrderController.java
+++ b/module-api/src/main/java/com/example/api/controller/order/OrderController.java
@@ -1,0 +1,29 @@
+package com.example.api.controller.order;
+
+import com.example.api.usecase.order.CreateOrderUseCase;
+import com.example.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/orders")
+@RequiredArgsConstructor
+public class OrderController {
+
+	private final CreateOrderUseCase createOrderUseCase;
+
+	@PostMapping
+	public ResponseEntity<ApiResponse<Void>> createOrder(
+		@AuthenticationPrincipal UserDetails userDetails
+	) {
+		System.out.println(userDetails);
+		return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse<>());
+	}
+
+}

--- a/module-api/src/main/java/com/example/api/controller/order/OrderController.java
+++ b/module-api/src/main/java/com/example/api/controller/order/OrderController.java
@@ -5,6 +5,7 @@ import com.example.api.dto.order.OrderResponse;
 import com.example.api.infra.auth.CustomUserDetails;
 import com.example.api.usecase.order.CreateOrderUseCase;
 import com.example.common.response.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -23,7 +24,8 @@ public class OrderController {
 
 	@PostMapping
 	public ResponseEntity<ApiResponse<OrderResponse.Create>> createOrder(
-		@AuthenticationPrincipal CustomUserDetails user, @RequestBody OrderRequest.Create request) {
+		@AuthenticationPrincipal CustomUserDetails user,
+		@Valid @RequestBody OrderRequest.Create request) {
 		return ResponseEntity.status(HttpStatus.OK)
 			.body(ApiResponse.success(createOrderUseCase.createOrder(user.getId(), request)));
 	}

--- a/module-api/src/main/java/com/example/api/controller/order/OrderController.java
+++ b/module-api/src/main/java/com/example/api/controller/order/OrderController.java
@@ -1,13 +1,16 @@
 package com.example.api.controller.order;
 
+import com.example.api.dto.order.OrderRequest;
+import com.example.api.dto.order.OrderResponse;
+import com.example.api.infra.auth.CustomUserDetails;
 import com.example.api.usecase.order.CreateOrderUseCase;
 import com.example.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,11 +22,10 @@ public class OrderController {
 	private final CreateOrderUseCase createOrderUseCase;
 
 	@PostMapping
-	public ResponseEntity<ApiResponse<Void>> createOrder(
-		@AuthenticationPrincipal UserDetails userDetails
-	) {
-		System.out.println(userDetails);
-		return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse<>());
+	public ResponseEntity<ApiResponse<OrderResponse.Create>> createOrder(
+		@AuthenticationPrincipal CustomUserDetails user, @RequestBody OrderRequest.Create request) {
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(ApiResponse.success(createOrderUseCase.createOrder(user.getId(), request)));
 	}
 
 }

--- a/module-api/src/main/java/com/example/api/controller/user/AddressController.java
+++ b/module-api/src/main/java/com/example/api/controller/user/AddressController.java
@@ -1,0 +1,33 @@
+package com.example.api.controller.user;
+
+import com.example.api.dto.user.AddressRequest;
+import com.example.api.infra.auth.CustomUserDetails;
+import com.example.api.usecase.user.CreateAddressUseCase;
+import com.example.common.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/me/addresses")
+@RequiredArgsConstructor
+public class AddressController {
+
+	private final CreateAddressUseCase createAddressUseCase;
+
+	@PostMapping
+	public ResponseEntity<ApiResponse<Void>> createAddress(
+		@AuthenticationPrincipal CustomUserDetails user,
+		@Valid @RequestBody AddressRequest.Create request
+	) {
+		createAddressUseCase.createAddress(user.getId(), request);
+		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(null));
+	}
+
+}

--- a/module-api/src/main/java/com/example/api/dto/order/OrderCreatedPayload.java
+++ b/module-api/src/main/java/com/example/api/dto/order/OrderCreatedPayload.java
@@ -10,18 +10,18 @@ import lombok.Getter;
 @AllArgsConstructor
 public class OrderCreatedPayload {
 
-	public Long orderId;
-	public Long userId;
-	public BigDecimal amount;
-	public List<Item> items;
-	public LocalDateTime occurredAt;
+	private Long orderId;
+	private Long userId;
+	private BigDecimal amount;
+	private List<Item> items;
+	private LocalDateTime occurredAt;
 
 	@Getter
 	public static class Item {
 
-		public Long productId;
-		public int quantity;
-		public BigDecimal price; // 단가 or 라인합, 팀 컨벤션에 맞춰 명확히
+		private Long productId;
+		private int quantity;
+		private BigDecimal price;
 
 		public Item(Long productId, int quantity, BigDecimal price) {
 			this.productId = productId;

--- a/module-api/src/main/java/com/example/api/dto/order/OrderCreatedPayload.java
+++ b/module-api/src/main/java/com/example/api/dto/order/OrderCreatedPayload.java
@@ -1,0 +1,33 @@
+package com.example.api.dto.order;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OrderCreatedPayload {
+
+	public Long orderId;
+	public Long userId;
+	public BigDecimal amount;
+	public List<Item> items;
+	public LocalDateTime occurredAt;
+
+	@Getter
+	public static class Item {
+
+		public Long productId;
+		public int quantity;
+		public BigDecimal price; // 단가 or 라인합, 팀 컨벤션에 맞춰 명확히
+
+		public Item(Long productId, int quantity, BigDecimal price) {
+			this.productId = productId;
+			this.quantity = quantity;
+			this.price = price;
+		}
+	}
+
+}

--- a/module-api/src/main/java/com/example/api/dto/order/OrderRequest.java
+++ b/module-api/src/main/java/com/example/api/dto/order/OrderRequest.java
@@ -1,0 +1,36 @@
+package com.example.api.dto.order;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class OrderRequest {
+
+	@Getter
+	@NoArgsConstructor
+	public static class Create {
+
+		@NotNull(message = "주소 ID는 필수입니다.")
+		private Long addressId;
+
+		@NotEmpty(message = "구매 항목은 최소 1개 이상이어야 합니다.")
+		@Valid
+		private List<OrderRequest.Item> items;
+	}
+
+	@Getter
+	@NoArgsConstructor
+	public static class Item {
+
+		@NotNull(message = "상품 ID는 필수입니다.")
+		private Long productId;
+
+		@Min(value = 1, message = "수량은 최소 1개 이상이어야 합니다.")
+		private int quantity;
+	}
+
+}

--- a/module-api/src/main/java/com/example/api/dto/order/OrderResponse.java
+++ b/module-api/src/main/java/com/example/api/dto/order/OrderResponse.java
@@ -1,0 +1,24 @@
+package com.example.api.dto.order;
+
+import com.example.domain.enums.OrderStatus;
+import java.math.BigDecimal;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class OrderResponse {
+
+	@Getter
+	@Builder
+	@AllArgsConstructor
+	public static class Create {
+
+		private Long id;
+		private String address;
+		private String addressDetail;
+		private Long userId;
+		private BigDecimal amount;
+		private OrderStatus status;
+	}
+
+}

--- a/module-api/src/main/java/com/example/api/dto/user/AddressRequest.java
+++ b/module-api/src/main/java/com/example/api/dto/user/AddressRequest.java
@@ -1,0 +1,29 @@
+package com.example.api.dto.user;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class AddressRequest {
+
+	@Getter
+	@NoArgsConstructor
+	public static class Create {
+
+		@NotBlank(message = "주소를 입력해주세요.")
+		private String address;
+
+		@NotBlank(message = "상세 주소를 입력해주세요.")
+		private String addressDetail;
+
+		@NotBlank(message = "연락처를 입력해주세요.")
+		@Pattern(regexp = "^0\\d{1,2}-\\d{3,4}-\\d{4}$", message = "핸드폰 번호 양식을 지켜주세요.")
+		private String phone;
+
+		@NotBlank(message = "받는 사람을 입력해주세요.")
+		private String recipientName;
+
+	}
+
+}

--- a/module-api/src/main/java/com/example/api/facade/auth/SocialAuthFacade.java
+++ b/module-api/src/main/java/com/example/api/facade/auth/SocialAuthFacade.java
@@ -27,7 +27,7 @@ public class SocialAuthFacade {
 	public Long getOrCreateSocialUser(SocialUserInfo info, String provider) {
 		String email = info.getEmail();
 		if (userFacade.existsByEmail(email)) {
-			return userFacade.findByEmail(email).getId();
+			return userFacade.getByEmail(email).getId();
 		}
 
 		String dummyPw = userDomainService.generatedDummyPw();
@@ -40,7 +40,7 @@ public class SocialAuthFacade {
 
 			return user.getId();
 		} catch (DataIntegrityViolationException e) {
-			return userFacade.findByEmail(email).getId();
+			return userFacade.getByEmail(email).getId();
 		}
 	}
 }

--- a/module-api/src/main/java/com/example/api/facade/order/OrderFacade.java
+++ b/module-api/src/main/java/com/example/api/facade/order/OrderFacade.java
@@ -1,17 +1,133 @@
 package com.example.api.facade.order;
 
+import com.example.api.dto.order.OrderCreatedPayload;
+import com.example.api.dto.order.OrderRequest;
+import com.example.api.dto.order.OrderRequest.Item;
+import com.example.api.dto.order.OrderResponse;
+import com.example.api.usecase.order.CreateOrderUseCase;
+import com.example.common.exception.ApiException;
+import com.example.common.exception.ErrorType;
+import com.example.domain.entity.Address;
+import com.example.domain.entity.Order;
+import com.example.domain.entity.OrderItem;
+import com.example.domain.entity.OutboxEvent;
+import com.example.domain.entity.Product;
+import com.example.domain.entity.User;
+import com.example.domain.enums.OrderStatus;
 import com.example.domain.repository.AddressRepository;
-import com.example.domain.repository.OrderItemRepository;
 import com.example.domain.repository.OrderRepository;
+import com.example.domain.repository.OutBoxRepository;
+import com.example.domain.repository.ProductRepository;
+import com.example.domain.repository.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
-public class OrderFacade {
+@Transactional(readOnly = true)
+public class OrderFacade implements CreateOrderUseCase {
 
 	private final AddressRepository addressRepository;
 	private final OrderRepository orderRepository;
-	private final OrderItemRepository orderItemRepository;
+	private final ProductRepository productRepository;
+	private final UserRepository userRepository;
+	private final OutBoxRepository outboxEventRepository;
+	private final ObjectMapper objectMapper;
 
+	/*
+	 * 유저/주소 확인
+	 * 같은 productId 병합
+	 * 상품 일괄 조회
+	 * 총액 계산
+	 * 재고 차감
+	 * 주문 저장
+	 * OutboxEvent 저장
+	 */
+
+	@Override
+	@Transactional
+	public OrderResponse.Create createOrder(Long userId, OrderRequest.Create dto) {
+
+		User user = userRepository.findById(userId).orElseThrow(
+			() -> new ApiException("존재하지 않는 유저입니다.", ErrorType.INVALID_PARAMETER,
+				HttpStatus.BAD_REQUEST));
+
+		Address address = addressRepository.findById(dto.getAddressId()).orElseThrow(
+			() -> new ApiException("존재하지 않는 주소입니다.", ErrorType.INVALID_PARAMETER,
+				HttpStatus.BAD_REQUEST));
+
+		if (!address.getUser().getId().equals(user.getId())) {
+			throw new ApiException("해당 회원의 주소지가 아닙니다.", ErrorType.INVALID_PARAMETER,
+				HttpStatus.FORBIDDEN);
+		}
+
+		Map<Long, Integer> qtyMap = new HashMap<>();
+		List<Item> items = dto.getItems();
+		for (Item item : items) {
+			qtyMap.merge(item.getProductId(), item.getQuantity(), Integer::sum);
+		}
+
+		List<Long> productIds = qtyMap.keySet().stream().sorted().toList();
+		Map<Long, Product> products = productRepository.findAllById(productIds).stream()
+			.collect(Collectors.toMap(Product::getId, p -> p));
+
+		if (products.size() != productIds.size()) {
+			Long missing = productIds.stream().filter(id -> !products.containsKey(id)).findFirst()
+				.orElse(null);
+			throw new ApiException("존재하지 않는 상품입니다. id= " + missing, ErrorType.INVALID_PARAMETER,
+				HttpStatus.BAD_REQUEST);
+		}
+
+		BigDecimal totalPrice = BigDecimal.ZERO;
+		List<OrderItem> orderItems = new ArrayList<>();
+		for (Long p : productIds) {
+			Product product = products.get(p);
+			int quantity = qtyMap.get(p);
+			BigDecimal price = product.getPrice().multiply(BigDecimal.valueOf(quantity));
+			totalPrice = totalPrice.add(price);
+
+			orderItems.add(OrderItem.of(null, product, quantity, product.getPrice()));
+		}
+
+		for (Long p : productIds) {
+			int updated = productRepository.decreaseStockIfEnough(p, qtyMap.get(p));
+			if (updated == 0) {
+				throw new ApiException("재고가 부족합니다. productId=" + p, ErrorType.INVALID_PARAMETER,
+					HttpStatus.BAD_REQUEST);
+			}
+		}
+
+		Order order = Order.of(address, user, totalPrice, OrderStatus.CREATED);
+		orderItems.forEach(order::addItem);
+		Order saved = orderRepository.save(order);
+
+		OrderCreatedPayload payload = new OrderCreatedPayload(saved.getId(),
+			saved.getUser().getId(), saved.getAmount(), saved.getItems().stream().map(
+			i -> new OrderCreatedPayload.Item(i.getProduct().getId(), i.getQuantity(),
+				i.getPrice())).toList(), saved.getCreatedAt());
+
+		String json;
+		try {
+			json = objectMapper.writeValueAsString(payload);
+		} catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+			throw new ApiException("주문 생성 이벤트 직렬화 실패", ErrorType.INTERNAL_SERVER_ERROR,
+				HttpStatus.INTERNAL_SERVER_ERROR);
+		}
+		OutboxEvent event = OutboxEvent.of("ORDER_CREATED", json);
+		outboxEventRepository.save(event);
+
+		return OrderResponse.Create.builder().id(saved.getId())
+			.address(saved.getAddress().getAddress())
+			.addressDetail(saved.getAddress().getAddressDetail()).userId(saved.getUser().getId())
+			.amount(saved.getAmount()).status(saved.getStatus()).build();
+	}
 }

--- a/module-api/src/main/java/com/example/api/facade/order/OrderFacade.java
+++ b/module-api/src/main/java/com/example/api/facade/order/OrderFacade.java
@@ -1,0 +1,17 @@
+package com.example.api.facade.order;
+
+import com.example.domain.repository.AddressRepository;
+import com.example.domain.repository.OrderItemRepository;
+import com.example.domain.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OrderFacade {
+
+	private final AddressRepository addressRepository;
+	private final OrderRepository orderRepository;
+	private final OrderItemRepository orderItemRepository;
+
+}

--- a/module-api/src/main/java/com/example/api/facade/user/AddressFacade.java
+++ b/module-api/src/main/java/com/example/api/facade/user/AddressFacade.java
@@ -1,0 +1,36 @@
+package com.example.api.facade.user;
+
+import com.example.api.dto.user.AddressRequest;
+import com.example.api.usecase.user.CreateAddressUseCase;
+import com.example.common.exception.ApiException;
+import com.example.common.exception.ErrorType;
+import com.example.domain.entity.Address;
+import com.example.domain.entity.User;
+import com.example.domain.repository.AddressRepository;
+import com.example.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AddressFacade implements CreateAddressUseCase {
+
+	private final AddressRepository addressRepository;
+	private final UserRepository userRepository;
+
+	@Transactional
+	public void createAddress(Long userId, AddressRequest.Create dto) {
+
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new ApiException("존재하지 않는 회원 번호", ErrorType.INVALID_PARAMETER,
+				HttpStatus.BAD_REQUEST));
+
+		Address address = Address.of(user, dto.getRecipientName(), dto.getPhone(), dto.getAddress(),
+			dto.getAddressDetail());
+
+		addressRepository.save(address);
+	}
+}

--- a/module-api/src/main/java/com/example/api/facade/user/UserFacade.java
+++ b/module-api/src/main/java/com/example/api/facade/user/UserFacade.java
@@ -24,7 +24,7 @@ public class UserFacade {
 		userRepository.save(user);
 	}
 
-	public User findByEmail(String email) {
+	public User getByEmail(String email) {
 		return userRepository.findByEmail(email)
 			.orElseThrow(() -> new ApiException("존재하지 않는 이메일", ErrorType.INVALID_PARAMETER,
 				HttpStatus.BAD_REQUEST));
@@ -32,6 +32,12 @@ public class UserFacade {
 
 	public boolean existsByEmail(String email) {
 		return userRepository.existsByEmail(email);
+	}
+
+	public User getById(Long id) {
+		return userRepository.findById(id)
+			.orElseThrow(() -> new ApiException("존재하지 않는 회원번호", ErrorType.INVALID_PARAMETER,
+				HttpStatus.BAD_REQUEST));
 	}
 
 }

--- a/module-api/src/main/java/com/example/api/infra/auth/CustomUserDetails.java
+++ b/module-api/src/main/java/com/example/api/infra/auth/CustomUserDetails.java
@@ -1,0 +1,66 @@
+package com.example.api.infra.auth;
+
+import java.util.Collection;
+import java.util.Collections;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class CustomUserDetails implements UserDetails {
+
+	private final Long id;
+	private final String nickname;
+	private final String email;
+	private final Collection<? extends GrantedAuthority> authorities;
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return authorities != null ? authorities : Collections.emptyList();
+	}
+
+	@Override
+	public String getPassword() {
+		return null;
+	}
+
+	@Override
+	public String getUsername() {
+		return this.email;
+	}
+
+	@Override
+	public boolean isAccountNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return true;
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return true;
+	}
+
+	public static CustomUserDetails of(
+		Long id, String email, String nickname, Collection<? extends GrantedAuthority> authorities
+	) {
+		return CustomUserDetails.builder()
+			.id(id)
+			.email(email)
+			.nickname(nickname)
+			.authorities(authorities)
+			.build();
+	}
+}

--- a/module-api/src/main/java/com/example/api/usecase/auth/SigninUseCase.java
+++ b/module-api/src/main/java/com/example/api/usecase/auth/SigninUseCase.java
@@ -19,7 +19,7 @@ public class SigninUseCase {
 
 	@Transactional(readOnly = true)
 	public String signIn(SigninRequest dto) {
-		User user = userFacade.findByEmail(dto.getEmail());
+		User user = userFacade.getByEmail(dto.getEmail());
 
 		userDomainService.isPasswordMatch(dto.getPassword(), user.getPassword());
 

--- a/module-api/src/main/java/com/example/api/usecase/auth/SigninUseCase.java
+++ b/module-api/src/main/java/com/example/api/usecase/auth/SigninUseCase.java
@@ -23,6 +23,6 @@ public class SigninUseCase {
 
 		userDomainService.isPasswordMatch(dto.getPassword(), user.getPassword());
 
-		return jwtUtil.generateToken(dto.getEmail());
+		return jwtUtil.generateToken(user.getId(), user.getEmail(), user.getNickname());
 	}
 }

--- a/module-api/src/main/java/com/example/api/usecase/auth/SocialLoginUseCase.java
+++ b/module-api/src/main/java/com/example/api/usecase/auth/SocialLoginUseCase.java
@@ -21,6 +21,6 @@ public class SocialLoginUseCase {
 
 		Long userId = socialLoginFacade.getOrCreateSocialUser(info, provider);
 
-		return jwtUtil.generateToken(userId.toString());
+		return jwtUtil.generateToken(userId, info.getEmail(), info.getEmail());
 	}
 }

--- a/module-api/src/main/java/com/example/api/usecase/order/CreateOrderUseCase.java
+++ b/module-api/src/main/java/com/example/api/usecase/order/CreateOrderUseCase.java
@@ -2,9 +2,7 @@ package com.example.api.usecase.order;
 
 import com.example.api.dto.order.OrderRequest;
 import com.example.api.dto.order.OrderResponse;
-import org.springframework.stereotype.Service;
 
-@Service
 public interface CreateOrderUseCase {
 
 	OrderResponse.Create createOrder(Long userId, OrderRequest.Create dto);

--- a/module-api/src/main/java/com/example/api/usecase/order/CreateOrderUseCase.java
+++ b/module-api/src/main/java/com/example/api/usecase/order/CreateOrderUseCase.java
@@ -1,0 +1,20 @@
+package com.example.api.usecase.order;
+
+import com.example.api.facade.order.OrderFacade;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CreateOrderUseCase {
+
+	private final OrderFacade orderFacade;
+
+	/**
+	 * 장바구니 확인 후, 주문 생성 요청
+	 * 결제 시도
+	 *
+	 */
+
+
+}

--- a/module-api/src/main/java/com/example/api/usecase/order/CreateOrderUseCase.java
+++ b/module-api/src/main/java/com/example/api/usecase/order/CreateOrderUseCase.java
@@ -1,20 +1,12 @@
 package com.example.api.usecase.order;
 
-import com.example.api.facade.order.OrderFacade;
-import lombok.RequiredArgsConstructor;
+import com.example.api.dto.order.OrderRequest;
+import com.example.api.dto.order.OrderResponse;
 import org.springframework.stereotype.Service;
 
 @Service
-@RequiredArgsConstructor
-public class CreateOrderUseCase {
+public interface CreateOrderUseCase {
 
-	private final OrderFacade orderFacade;
-
-	/**
-	 * 장바구니 확인 후, 주문 생성 요청
-	 * 결제 시도
-	 *
-	 */
-
+	OrderResponse.Create createOrder(Long userId, OrderRequest.Create dto);
 
 }

--- a/module-api/src/main/java/com/example/api/usecase/user/CreateAddressUseCase.java
+++ b/module-api/src/main/java/com/example/api/usecase/user/CreateAddressUseCase.java
@@ -1,0 +1,11 @@
+package com.example.api.usecase.user;
+
+import com.example.api.dto.user.AddressRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface CreateAddressUseCase {
+
+	void createAddress(Long userId, AddressRequest.Create dto);
+
+}

--- a/module-common/src/main/java/com/example/common/exception/ErrorType.java
+++ b/module-common/src/main/java/com/example/common/exception/ErrorType.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorType {
 	NO_RESOURCE(HttpStatus.NOT_FOUND, "존재하지 않는 데이터입니다."),
 	INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "잘못된 파라미터 요청입니다."),
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
 	EXTERNAL_API_ERROR(HttpStatus.BAD_GATEWAY, "외부 API 호출 에러입니다."),
 	NOT_LOGGED_IN(HttpStatus.UNAUTHORIZED, "로그인이 필요한 사용자입니다."),
 	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "토큰 에러입니다.");

--- a/module-domain/src/main/java/com/example/domain/entity/Address.java
+++ b/module-domain/src/main/java/com/example/domain/entity/Address.java
@@ -42,12 +42,12 @@ public class Address extends BaseTime {
 
 	public static Address of(User user, String recipientName, String phone, String address,
 		String addressDetail) {
-		Address address1 = new Address();
-		address1.user = user;
-		address1.recipientName = recipientName;
-		address1.phone = phone;
-		address1.address = address;
-		address1.addressDetail = addressDetail;
-		return address1;
+		Address entity = new Address();
+		entity.user = user;
+		entity.recipientName = recipientName;
+		entity.phone = phone;
+		entity.address = address;
+		entity.addressDetail = addressDetail;
+		return entity;
 	}
 }

--- a/module-domain/src/main/java/com/example/domain/entity/Address.java
+++ b/module-domain/src/main/java/com/example/domain/entity/Address.java
@@ -1,0 +1,38 @@
+package com.example.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "address")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Address extends BaseTime {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@JoinColumn(name = "user_id")
+	@ManyToOne(fetch = FetchType.LAZY)
+	private User user;
+
+	@Column(nullable = false)
+	private String phone;
+
+	@Column(nullable = false)
+	private String address;
+
+	@Column(nullable = false)
+	private String addressDetail;
+}

--- a/module-domain/src/main/java/com/example/domain/entity/Address.java
+++ b/module-domain/src/main/java/com/example/domain/entity/Address.java
@@ -28,11 +28,26 @@ public class Address extends BaseTime {
 	private User user;
 
 	@Column(nullable = false)
+	private String recipientName;
+
+	@Column(nullable = false)
 	private String phone;
 
 	@Column(nullable = false)
 	private String address;
 
+
 	@Column(nullable = false)
 	private String addressDetail;
+
+	public static Address of(User user, String recipientName, String phone, String address,
+		String addressDetail) {
+		Address address1 = new Address();
+		address1.user = user;
+		address1.recipientName = recipientName;
+		address1.phone = phone;
+		address1.address = address;
+		address1.addressDetail = addressDetail;
+		return address1;
+	}
 }

--- a/module-domain/src/main/java/com/example/domain/entity/Order.java
+++ b/module-domain/src/main/java/com/example/domain/entity/Order.java
@@ -1,6 +1,7 @@
 package com.example.domain.entity;
 
 import com.example.domain.enums.OrderStatus;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -11,8 +12,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -31,6 +35,10 @@ public class Order extends BaseTime {
 	@ManyToOne(fetch = FetchType.LAZY)
 	private Address address;
 
+	@JoinColumn(name = "user_id")
+	@ManyToOne(fetch = FetchType.LAZY)
+	private User user;
+
 	@Column(nullable = false)
 	private BigDecimal amount;
 
@@ -38,4 +46,20 @@ public class Order extends BaseTime {
 	@Enumerated(EnumType.STRING)
 	private OrderStatus status;
 
+	@OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<OrderItem> items = new ArrayList<>();
+
+	public void addItem(OrderItem item) {
+		items.add(item);
+		item.setOrder(this);
+	}
+
+	public static Order of(Address address, User user, BigDecimal amount, OrderStatus status) {
+		Order order = new Order();
+		order.address = address;
+		order.user = user;
+		order.amount = amount;
+		order.status = status;
+		return order;
+	}
 }

--- a/module-domain/src/main/java/com/example/domain/entity/Order.java
+++ b/module-domain/src/main/java/com/example/domain/entity/Order.java
@@ -1,0 +1,41 @@
+package com.example.domain.entity;
+
+import com.example.domain.enums.OrderStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "orders")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Order extends BaseTime {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private long id;
+
+	@JoinColumn(name = "address_id")
+	@ManyToOne(fetch = FetchType.LAZY)
+	private Address address;
+
+	@Column(nullable = false)
+	private BigDecimal amount;
+
+	@Column(nullable = false)
+	@Enumerated(EnumType.STRING)
+	private OrderStatus status;
+
+}

--- a/module-domain/src/main/java/com/example/domain/entity/OrderItem.java
+++ b/module-domain/src/main/java/com/example/domain/entity/OrderItem.java
@@ -1,0 +1,40 @@
+package com.example.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "order_items")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderItem {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@JoinColumn(name = "order_id")
+	@ManyToOne(fetch = FetchType.LAZY)
+	private Order order;
+
+	@JoinColumn(name = "product_id")
+	@ManyToOne(fetch = FetchType.LAZY)
+	private Product product;
+
+	@Column(nullable = false)
+	private int quantity;
+
+	@Column(nullable = false)
+	private BigDecimal price;
+}

--- a/module-domain/src/main/java/com/example/domain/entity/OrderItem.java
+++ b/module-domain/src/main/java/com/example/domain/entity/OrderItem.java
@@ -37,4 +37,26 @@ public class OrderItem {
 
 	@Column(nullable = false)
 	private BigDecimal price;
+
+	public static OrderItem of(Order order, Product product, int quantity, BigDecimal price) {
+		OrderItem orderItem = new OrderItem();
+		orderItem.order = order;
+		orderItem.product = product;
+		orderItem.quantity = quantity;
+		orderItem.price = price;
+		return orderItem;
+	}
+
+	public void setOrder(Order order) {
+		if (this.order == order) {
+			return;
+		}
+		if (this.order != null) {
+			this.order.getItems().remove(this);
+		}
+		this.order = order;
+		if (order != null && !order.getItems().contains(this)) {
+			order.getItems().add(this);
+		}
+	}
 }

--- a/module-domain/src/main/java/com/example/domain/entity/OutboxEvent.java
+++ b/module-domain/src/main/java/com/example/domain/entity/OutboxEvent.java
@@ -33,5 +33,12 @@ public class OutboxEvent extends BaseTime {
 	@Enumerated(value = EnumType.STRING)
 	@Column(nullable = false)
 	private OutBoxStatus status = OutBoxStatus.PENDING;
-	
+
+	public static OutboxEvent of(String eventType, String payloadJson) {
+		OutboxEvent e = new OutboxEvent();
+		e.eventType = eventType;
+		e.payload = payloadJson;
+		e.status = OutBoxStatus.PENDING;
+		return e;
+	}
 }

--- a/module-domain/src/main/java/com/example/domain/entity/OutboxEvent.java
+++ b/module-domain/src/main/java/com/example/domain/entity/OutboxEvent.java
@@ -1,0 +1,37 @@
+package com.example.domain.entity;
+
+import com.example.domain.enums.OutBoxStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "outbox_event")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OutboxEvent extends BaseTime {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	@Column(nullable = false)
+	private String eventType;
+
+	@Lob
+	@Column(nullable = false)
+	private String payload;
+
+	@Enumerated(value = EnumType.STRING)
+	@Column(nullable = false)
+	private OutBoxStatus status = OutBoxStatus.PENDING;
+	
+}

--- a/module-domain/src/main/java/com/example/domain/enums/OrderStatus.java
+++ b/module-domain/src/main/java/com/example/domain/enums/OrderStatus.java
@@ -1,0 +1,17 @@
+package com.example.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrderStatus {
+	CREATED("주문 생성"),
+	PAID("결제 완료"),
+	CANCELLED("주문 취소"),
+	FULFILLING("주문 준비중"),
+	SHIPPED("배송 중"),
+	DELIVERED("배송 완료");
+
+	private final String status;
+}

--- a/module-domain/src/main/java/com/example/domain/enums/OutBoxStatus.java
+++ b/module-domain/src/main/java/com/example/domain/enums/OutBoxStatus.java
@@ -1,0 +1,14 @@
+package com.example.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OutBoxStatus {
+	PENDING("발행 대기"),
+	PROCESSED("발행 완료"),
+	FAILED("발행 실패");
+
+	private final String desc;
+}

--- a/module-domain/src/main/java/com/example/domain/repository/AddressRepository.java
+++ b/module-domain/src/main/java/com/example/domain/repository/AddressRepository.java
@@ -1,0 +1,10 @@
+package com.example.domain.repository;
+
+import com.example.domain.entity.Address;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AddressRepository extends JpaRepository<Address, Long> {
+
+}

--- a/module-domain/src/main/java/com/example/domain/repository/OrderItemRepository.java
+++ b/module-domain/src/main/java/com/example/domain/repository/OrderItemRepository.java
@@ -1,0 +1,10 @@
+package com.example.domain.repository;
+
+import com.example.domain.entity.OrderItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
+
+}

--- a/module-domain/src/main/java/com/example/domain/repository/OrderRepository.java
+++ b/module-domain/src/main/java/com/example/domain/repository/OrderRepository.java
@@ -1,0 +1,10 @@
+package com.example.domain.repository;
+
+import com.example.domain.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OrderRepository extends JpaRepository<Order, Long> {
+
+}

--- a/module-domain/src/main/java/com/example/domain/repository/OutBoxRepository.java
+++ b/module-domain/src/main/java/com/example/domain/repository/OutBoxRepository.java
@@ -1,0 +1,10 @@
+package com.example.domain.repository;
+
+import com.example.domain.entity.OutboxEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OutBoxRepository extends JpaRepository<OutboxEvent, Long> {
+
+}

--- a/module-domain/src/main/java/com/example/domain/repository/ProductRepository.java
+++ b/module-domain/src/main/java/com/example/domain/repository/ProductRepository.java
@@ -2,9 +2,21 @@ package com.example.domain.repository;
 
 import com.example.domain.entity.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long>, ProductCustomRepository {
 
+	@Modifying(clearAutomatically = true, flushAutomatically = true)
+	@Query("""
+		    UPDATE Product p
+		    SET p.stock = p.stock - :quantity
+		    WHERE p.id = :productId
+		      AND p.stock >= :quantity
+		""")
+	int decreaseStockIfEnough(@Param("productId") Long productId,
+		@Param("quantity") int quantity);
 }


### PR DESCRIPTION
close #18

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/18 -> dev

### 변경 사항
- 배송지 등록 기능 추가
- CustomUserDetails 추가하여 유저 정보 저장
- order 생성 기능 추가 
  - order 생성 -> orderItem 생성 -> outboxevnet 생성

### 테스트 결과
정상 작동


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 주문 생성 API 추가: POST /api/v1/orders — 주문 ID·총액·상태 반환.
  * 내 배송지 등록 API 추가: POST /api/v1/me/addresses — 201 Created.
  * JWT 인증 도입 및 토큰에 사용자 ID/이메일/닉네임 포함, 무상태(security) 적용.
  * 주문 시 재고 검증(부족시 오류) 및 아웃박스 기반 주문 생성 이벤트 발행.
* **기타**
  * 공통 오류 유형에 INTERNAL_SERVER_ERROR 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->